### PR TITLE
Lower pagination limit from 1000 to 50 to fix addon fetching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,8 +58,6 @@ idea {
 repositories {
     mavenCentral()
     jcenter()
-    maven(url = "https://dl.bintray.com/kotlin/kotlinx")
-    maven(url = "http://dl.bintray.com/kotlin/ktor")
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    // The org.jetbrains.kotlin.jvm plugin requires a repository
+    // where to download the Kotlin compiler dependencies from.
     mavenCentral()
-}
-
-dependencies {
-
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        maven(url = "https://dl.bintray.com/kotlin/kotlin-eap")
+        mavenCentral()
         gradlePluginPortal()
     }
     resolutionStrategy {

--- a/src/main/kotlin/moe/nikky/curseproxy/curse/CurseClient.kt
+++ b/src/main/kotlin/moe/nikky/curseproxy/curse/CurseClient.kt
@@ -196,7 +196,7 @@ object CurseClient : KoinComponent {
         isSortDescending: Boolean = true,
         gameVersions: List<String>? = null,
         index: Int = 0,
-        pageSize: Int = 1000,
+        pageSize: Int = 50,
         searchFilter: String? = null
     ): List<Addon>? {
         val url = "$ADDON_API/addon/search"
@@ -250,10 +250,10 @@ object CurseClient : KoinComponent {
         sort: AddonSortMethod = AddonSortMethod.Featured,
         isSortDescending: Boolean = true,
         gameVersions: List<String>? = null,
-        pageSize: Int = 1000,
+        pageSize: Int = 50,
         searchFilter: String? = null
     ): List<Addon> {
-        require(pageSize <= 1000) { "curse api limits pagesize to 1000" }
+        require(pageSize <= 50) { "curse api limits pagesize to 50" }
 
         val n = 4
         var index = 0

--- a/src/main/kotlin/moe/nikky/curseproxy/curse/references/ServiceClient.cs
+++ b/src/main/kotlin/moe/nikky/curseproxy/curse/references/ServiceClient.cs
@@ -47,7 +47,7 @@ namespace Curse.Radium.Addons.ServiceClient
       GameVersion,
     }
 
-    public ServiceResponse<List<Addon>> GetAddonsByCriteria(int gameId, int sectionId = -1, int categoryId = -1, AddonSortMethod sort = AddonSortMethod.Featured, bool isSortDescending = true, string gameVersion = null, int index = 0, int pageSize = 1000, string searchFilter = null)
+    public ServiceResponse<List<Addon>> GetAddonsByCriteria(int gameId, int sectionId = -1, int categoryId = -1, AddonSortMethod sort = AddonSortMethod.Featured, bool isSortDescending = true, string gameVersion = null, int index = 0, int pageSize = 50, string searchFilter = null)
     {
       return this.Get<List<Addon>>(string.Format("api/addon/search?gameId={0}&sectionId={1}&categoryId={2}&gameVersion={3}&index={4}&pageSize={5}&searchFilter={6}&sort={7}&sortDescending={8}", (object) gameId, (object) sectionId, (object) categoryId, (object) gameVersion, (object) index, (object) pageSize, (object) searchFilter, (object) sort, (object) isSortDescending.ToString().ToLower()));
     }

--- a/versions.properties
+++ b/versions.properties
@@ -5,6 +5,7 @@
 ## Please, don't put extra comments in that file yet, keeping them is not supported yet.
 
 plugin.com.github.johnrengelman.shadow=6.0.0
+##                         # available=7.1.1
 
 plugin.com.squareup.sqldelight=version.sqldelight
 
@@ -13,38 +14,50 @@ plugin.org.jetbrains.kotlin.jvm=version.kotlin
 plugin.org.jetbrains.kotlin.plugin-serialization=version.kotlin
 
 version.com.apurebase..kgraphql=0.15.0
+##                  # available=0.17.14
 
 version.com.fasterxml.jackson.core..jackson-databind=2.11.1
+##                                       # available=2.13.1
 
 version.com.fasterxml.jackson.module..jackson-module-kotlin=2.11.1
+##                                              # available=2.13.1
 
 version.com.github.kittinunf.fuel..fuel=2.2.3
+##                          # available=2.3.1
 
 version.com.github.kittinunf.fuel..fuel-coroutines=2.2.3
+##                                     # available=2.3.1
 
 version.com.github.kittinunf.fuel..fuel-kotlinx-serialization=2.2.3
-
-version.junit.junit=4.13
-
-version.kotlin=1.3.72
-
-version.kotlinx.coroutines=1.3.7
-##             # available=1.3.8
-##             # available=1.3.8-1.4.0-rc-218
-
- version.ktor=1.3.2
-### available=1.3.2-1.4-M1-release-99
-### available=1.3.2-1.4.0-rc
-
-version.logback-classic=1.2.3
-##          # available=1.3.0-alpha5
-
-version.org.koin..koin-ktor=2.1.6
-##              # available=3.0.0-alpha-2
-
-version.sqldelight=1.4.0
+##                                                # available=2.3.1
 
 version.io.github.microutils..kotlin-logging=1.8.3
+##                               # available=2.1.21
+
+version.junit.junit=4.13
+##      # available=4.13.2
+
+version.kotlin=1.3.72
+## # available=1.6.10
+
+version.kotlinx.coroutines=1.3.7
+##             # available=1.6.0
+
+ version.ktor=1.3.2
+### available=1.6.7
+### available=2.0.0-beta-1
+
+version.logback-classic=1.2.3
+##          # available=1.2.10
+##          # available=1.3.0-alpha12
+
+version.org.koin..koin-ktor=2.1.6
+##              # available=2.2.2
+##              # available=3.0.1-alpha-5
 
 version.org.koin..koin-logger-slf4j=2.1.6
-##                      # available=3.0.0-alpha-2
+##                      # available=2.2.2
+##                      # available=3.0.1-alpha-5
+
+version.sqldelight=1.4.0
+##     # available=1.5.3


### PR DESCRIPTION
This fixes the 400 errors from the Cloudfront API, ultimately un-breaking curseproxy.